### PR TITLE
Drop x86_64-apple-darwin from release matrix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@
 # enables single-target debugging (e.g. running the upload or tap-PR step
 # locally against an artifact you produced manually).
 
-# GitHub (scripts/homebrew_pr.sh)
+# GitHub (submit_build.sh)
 # Personal access token with `repo` scope on the tap repo
 # — github.com/settings/tokens. Same env var Peel uses, so a single .env
 # file works across both projects.
@@ -18,7 +18,7 @@ GITHUB_PERSONAL_ACCESS_TOKEN=
 # https://github.com/Homebrew/homebrew-core.git and the script keeps working.
 HOMEBREW_TAP_REPO_URL=https://github.com/douglaslassance/homebrew-tap.git
 
-# Cloudflare R2 (scripts/upload_build.sh)
+# Cloudflare R2 (upload_build.sh)
 # Found in Cloudflare Dashboard > R2 > Manage R2 API tokens.
 S3_ACCOUNT_ID=
 S3_ACCESS_KEY_ID=
@@ -29,14 +29,14 @@ S3_BUCKET_NAME=
 # e.g. https://s3.douglaslassance.me — used for cache-purge URLs.
 S3_PUBLIC_URL=
 
-# Cloudflare KV (scripts/upload_build.sh)
+# Cloudflare KV (upload_build.sh)
 # Namespace ID for the KV record that backs api.douglaslassance.me/gitalong
 # (latest version + per-target download counters + extension overrides).
 # Look up via Cloudflare Dashboard > Workers & Pages > KV, or
 # `wrangler kv namespace list`.
 CLOUDFLARE_KV_NAMESPACE_ID=
 
-# Cloudflare Cache Purge (scripts/upload_build.sh) — optional
+# Cloudflare Cache Purge (upload_build.sh) — optional
 # Without these the upload still succeeds but the CDN may serve stale
 # tarballs/zips for up to its TTL.
 # Zone ID — Cloudflare Dashboard > your domain > Overview (right sidebar).

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -188,9 +188,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ZONE_ID: ${{ secrets.CLOUDFLARE_ZONE_ID }}
           CLOUDFLARE_KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}
-        run: ./scripts/upload_build.sh ${{ needs.detect-version.outputs.version }}
+        run: ./upload_build.sh ${{ needs.detect-version.outputs.version }}
 
       # Homebrew tap submission is intentionally not part of CD — it's a
       # local-only step you run from your laptop after the artifacts are in
-      # R2. See scripts/homebrew_pr.sh; it reads the .sha256 sidecars from
+      # R2. See submit_build.sh; it reads the .sha256 sidecars from
       # S3_PUBLIC_URL so no local build is needed.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -82,11 +82,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # macOS is Apple-Silicon-only — Intel Macs aren't a supported
+          # release target. Anyone on Intel can `cargo install gitalong`.
           - target: aarch64-apple-darwin
             os: macos-15
-            archive: tar.gz
-          - target: x86_64-apple-darwin
-            os: macos-13
             archive: tar.gz
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-24.04

--- a/Formula/gitalong.rb.template
+++ b/Formula/gitalong.rb.template
@@ -5,13 +5,10 @@ class Gitalong < Formula
   license "MIT"
 
   on_macos do
+    # Apple Silicon only. Intel Macs install via `cargo install gitalong`.
     on_arm do
       url "https://api.douglaslassance.me/gitalong/download/#{version}/aarch64-apple-darwin"
       sha256 "{{SHA256_AARCH64_APPLE_DARWIN}}"
-    end
-    on_intel do
-      url "https://api.douglaslassance.me/gitalong/download/#{version}/x86_64-apple-darwin"
-      sha256 "{{SHA256_X86_64_APPLE_DARWIN}}"
     end
   end
 

--- a/scripts/submit_build.sh
+++ b/scripts/submit_build.sh
@@ -2,30 +2,43 @@
 #
 # Renders Formula/gitalong.rb from the in-repo template, fetching the SHA256
 # sidecars over HTTPS from S3_PUBLIC_URL (so this can run from a laptop after
-# CI has uploaded artifacts — no local build required), then opens a PR on
-# the Homebrew tap identified by HOMEBREW_TAP_REPO_URL.
+# CI has uploaded artifacts — no local build required), then pushes a release
+# branch to the Homebrew tap identified by HOMEBREW_TAP_REPO_URL.
+#
+# Mirrors Peel's submit_build.sh: pass --pull-request to also open a PR
+# against the tap. Without the flag the branch is just pushed and the tap
+# owner merges manually.
 #
 # Will switch to homebrew-core when that becomes possible by changing only
 # HOMEBREW_TAP_REPO_URL.
 
 set -euo pipefail
 
-if [[ "${1-}" == "-h" || "${1-}" == "--help" ]]; then
-    cat <<EOF
-homebrew_pr.sh - Open a Homebrew tap PR with the new formula
-Usage: ./scripts/homebrew_pr.sh <version>
+PULL_REQUEST=false
+ARGS=()
+for arg in "$@"; do
+    case "$arg" in
+        -h|--help)
+            cat <<EOF
+submit_build.sh - Push (and optionally PR) the new formula to the Homebrew tap
+Usage: ./scripts/submit_build.sh [--pull-request] <version>
 
 Run this locally after CI has uploaded the release to R2. Fetches each
 target's .sha256 sidecar over HTTPS, renders the formula template, and
-pushes a branch + PR to the configured tap.
+pushes a branch to the configured tap. With --pull-request, also opens a
+PR back to the tap's main.
 
 Required env (from .env):
   GITHUB_PERSONAL_ACCESS_TOKEN  GitHub PAT with \`repo\` scope on the tap
   HOMEBREW_TAP_REPO_URL         e.g. https://github.com/douglaslassance/homebrew-tap.git
   S3_PUBLIC_URL                 e.g. https://s3.douglaslassance.me
 EOF
-    exit 0
-fi
+            exit 0
+            ;;
+        --pull-request) PULL_REQUEST=true ;;
+        *) ARGS+=("$arg") ;;
+    esac
+done
 
 if [[ -f .env ]]; then
     # shellcheck disable=SC1091
@@ -33,7 +46,7 @@ if [[ -f .env ]]; then
 fi
 
 REPO_NAME="gitalong"
-VERSION="${1:?version required}"
+VERSION="${ARGS[0]:?version required}"
 
 missing=()
 [[ -z "${GITHUB_PERSONAL_ACCESS_TOKEN:-}" ]] && missing+=("GITHUB_PERSONAL_ACCESS_TOKEN")
@@ -44,8 +57,8 @@ if (( ${#missing[@]} )); then
     exit 1
 fi
 
-# Parse owner/repo from the tap URL for `gh pr create --repo`.
-# Accepts both .git suffix and bare HTTPS; strips either.
+# Parse owner/repo from the tap URL for `gh pr create --repo`. Accepts both
+# .git suffix and bare HTTPS; strips either.
 TAP_SLUG=$(echo "$HOMEBREW_TAP_REPO_URL" \
     | sed -E 's#^https?://[^/]+/##; s#\.git$##')
 if [[ ! "$TAP_SLUG" =~ ^[^/]+/[^/]+$ ]]; then
@@ -107,7 +120,7 @@ cd "$WORKTREE"
 git config user.email "actions@github.com"
 git config user.name "github-actions[bot]"
 
-BRANCH="${REPO_NAME}-${VERSION}"
+BRANCH="bump-${REPO_NAME}-${VERSION}"
 git checkout -b "$BRANCH"
 
 mkdir -p Formula
@@ -119,23 +132,26 @@ if git diff --cached --quiet; then
     exit 0
 fi
 
-git commit -m "Update ${REPO_NAME} to ${VERSION}"
+git commit -m "${REPO_NAME} ${VERSION}"
 git -c "url.https://x-access-token:${GITHUB_PERSONAL_ACCESS_TOKEN}@github.com/.insteadOf=https://github.com/" \
     push --force-with-lease origin "$BRANCH"
 
-# --- Open the PR ---
-if ! command -v gh >/dev/null 2>&1; then
-    echo "Installing gh CLI..."
-    type apt-get >/dev/null 2>&1 && sudo apt-get install -y gh \
-        || curl -fsSL https://cli.github.com/install.sh | sh
+# --- Open the PR (only if asked) ---
+if [ "$PULL_REQUEST" = true ]; then
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "Installing gh CLI..."
+        type apt-get >/dev/null 2>&1 && sudo apt-get install -y gh \
+            || curl -fsSL https://cli.github.com/install.sh | sh
+    fi
+
+    # TODO: If the repo is not a fork make pull request to default branch, if it's a fork make pull request to upstream default branch.
+    GH_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN" gh pr create \
+        --repo "$TAP_SLUG" \
+        --head "$BRANCH" \
+        --base main \
+        --title "${REPO_NAME} ${VERSION}" \
+        --body "Automated bump from \`${REPO_NAME}\` ${VERSION} release. Built artifacts in R2; sha256s in this commit." \
+        || echo "PR may already exist for ${BRANCH}; skipping create."
 fi
 
-GH_TOKEN="$GITHUB_PERSONAL_ACCESS_TOKEN" gh pr create \
-    --repo "$TAP_SLUG" \
-    --head "$BRANCH" \
-    --base main \
-    --title "Update ${REPO_NAME} to ${VERSION}" \
-    --body "Automated bump from \`${REPO_NAME}\` ${VERSION} release. Built artifacts in R2; sha256s in this commit." \
-    || echo "PR may already exist for ${BRANCH}; skipping create."
-
-echo "Homebrew tap PR step complete."
+echo "Submission complete."

--- a/submit_build.sh
+++ b/submit_build.sh
@@ -70,7 +70,6 @@ fi
 # uploaded to R2 but isn't a Homebrew target.
 TARGETS=(
     "aarch64-apple-darwin"
-    "x86_64-apple-darwin"
     "aarch64-unknown-linux-gnu"
     "x86_64-unknown-linux-gnu"
 )
@@ -99,7 +98,6 @@ RENDERED=$(mktemp)
 sed \
     -e "s|{{VERSION}}|${VERSION}|g" \
     -e "s|{{SHA256_AARCH64_APPLE_DARWIN}}|${SHA["aarch64-apple-darwin"]}|g" \
-    -e "s|{{SHA256_X86_64_APPLE_DARWIN}}|${SHA["x86_64-apple-darwin"]}|g" \
     -e "s|{{SHA256_AARCH64_UNKNOWN_LINUX_GNU}}|${SHA["aarch64-unknown-linux-gnu"]}|g" \
     -e "s|{{SHA256_X86_64_UNKNOWN_LINUX_GNU}}|${SHA["x86_64-unknown-linux-gnu"]}|g" \
     "$TEMPLATE" > "$RENDERED"

--- a/submit_build.sh
+++ b/submit_build.sh
@@ -21,7 +21,7 @@ for arg in "$@"; do
         -h|--help)
             cat <<EOF
 submit_build.sh - Push (and optionally PR) the new formula to the Homebrew tap
-Usage: ./scripts/submit_build.sh [--pull-request] <version>
+Usage: ./submit_build.sh [--pull-request] <version>
 
 Run this locally after CI has uploaded the release to R2. Fetches each
 target's .sha256 sidecar over HTTPS, renders the formula template, and

--- a/upload_build.sh
+++ b/upload_build.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 if [[ "${1-}" == "-h" || "${1-}" == "--help" ]]; then
     cat <<EOF
 upload_build.sh - Upload release artifacts to Cloudflare R2 and update KV
-Usage: ./scripts/upload_build.sh <version>
+Usage: ./upload_build.sh <version>
 
 Reads dist/gitalong-<version>-*.{tar.gz,zip}.
 EOF


### PR DESCRIPTION
Apple-Silicon-only on macOS — Intel runners (`macos-13`) sit waiting for runner availability and the Intel Mac population in 2026 is small enough that gating on its build delays releases for everyone else. Anyone on an Intel Mac can `cargo install gitalong`. Mirrors Peel's arm64-only stance.